### PR TITLE
add delay after promise resolves

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,20 @@
 'use strict';
 module.exports = function (ms) {
-	return new Promise(function (resolve) {
-		setTimeout(resolve, ms || 0);
+	ms = ms || 0;
+
+	var promise = new Promise(function (resolve) {
+		setTimeout(resolve, ms);
 	});
+
+	function thunk(result) {
+		return new Promise(function (resolve) {
+			setTimeout(function () {
+				resolve(result);
+			}, ms);
+		});
+	}
+
+	thunk.then = promise.then.bind(promise);
+
+	return thunk;
 };

--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,16 @@ $ npm install --save delay
 ```js
 const delay = require('delay');
 
+delay(200)
+	.then(() => {
+		// executed after 200 milliseconds
+	});
+
 somePromise()
 	.then(delay(100))
-	.then(() => {
-		// executed after 100 milliseconds
+	.then(result => {
+		// executed 100 milliseconds after somePromise resolves
+		// the result from somePromise is passed through
 	});
 ```
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,19 @@
+'use strict';
+
 import test from 'ava';
-import fn from './';
+import delay from './';
 
 test(async t => {
 	const date = Date.now();
-	await fn(50);
+	await delay(50);
 	const diff = Date.now() - date;
 	t.true(diff > 30 && diff < 70);
+});
+
+test(async t => {
+	const date = Date.now();
+	var result = await Promise.resolve('foo').then(delay(50));
+	const diff = Date.now() - date;
+	t.true(diff > 30 && diff < 80);
+	t.is(result, 'foo');
 });


### PR DESCRIPTION
This way keeps the return of `delay(200)` a promise.

I think #4 is a cleaner alternative.