### PR TITLE
return a thunk for a promise instead of a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 'use strict';
 module.exports = function (ms) {
-	return new Promise(function (resolve) {
-		setTimeout(resolve, ms || 0);
-	});
+	return function delay(result) {
+		return new Promise(function (resolve) {
+			setTimeout(function () {
+				resolve(result);
+			}, ms || 0);
+		});
+	};
 };

--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,17 @@ $ npm install --save delay
 ```js
 const delay = require('delay');
 
+delay(200)('foo')
+	.then(result => {
+		// executed after 200 milliseconds
+		result === 'foo'; // true
+	});
+
 somePromise()
 	.then(delay(100))
-	.then(() => {
-		// executed after 100 milliseconds
+	.then(result => {
+		// executed 100 milliseconds after somePromise resolves
+		// the result from somePromise is passed through
 	});
 ```
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,19 @@
+'use strict';
+
 import test from 'ava';
-import fn from './';
+import delay from './';
 
 test(async t => {
 	const date = Date.now();
-	await fn(50);
+	await delay(50)();
 	const diff = Date.now() - date;
 	t.true(diff > 30 && diff < 70);
+});
+
+test(async t => {
+	const date = Date.now();
+	var result = await Promise.resolve('foo').then(delay(50));
+	const diff = Date.now() - date;
+	t.true(diff > 30 && diff < 80);
+	t.is(result, 'foo');
 });


### PR DESCRIPTION
This breaks the original API more than #3, but it's implementation is way cleaner and easier to understand:

```js
delay(200)().then(...)
// or
promiseFn().then(delay(200))
```