### PR TITLE
Make the thunk more Promise-like.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (ms) {
 	}
 
 	thunk.then = promise.then.bind(promise);
+	thunk.catch = promise.catch.bind(promise);
 
 	return thunk;
 };


### PR DESCRIPTION
It's a lot more useful if you have `.catch`, otherwise you can't use it as a promise. (I needed this for AVA).