### PR TITLE
Add `.cancel()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,34 +1,48 @@
 'use strict';
+const defer = require('p-defer');
+
+class CancelError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = 'CancelError';
+	}
+}
 
 const generate = willResolve => function (ms, value) {
 	ms = ms || 0;
+	const useValue = (arguments.length > 1);
+	let result = value;
 
-	// If supplied, the thunk will override promise results with `value`.
-	const useValue = arguments.length > 1;
+	const delaying = defer();
+	const promise = delaying.promise;
 
-	let promise;
+	let timeout = setTimeout(() => {
+		const settle = willResolve ? delaying.resolve : delaying.reject;
+		settle(result);
+	}, ms);
 
-	const thunk = result => {
-		if (promise) {
-			// Prevent unhandled rejection errors if promise is never used, and only used as a thunk
-			promise.catch(() => {});
+	const thunk = thunkResult => {
+		if (!useValue) {
+			result = thunkResult;
 		}
-		return new Promise((resolve, reject) => {
-			setTimeout(
-				willResolve ? resolve : reject,
-				ms,
-				useValue ? value : result
-			);
-		});
+		return promise;
 	};
 
-	promise = thunk(value);
 	thunk.then = promise.then.bind(promise);
 	thunk.catch = promise.catch.bind(promise);
 	thunk._actualPromise = promise;
+
+	thunk.cancel = () => {
+		if (timeout) {
+			clearTimeout(timeout);
+			timeout = null;
+			delaying.reject(new CancelError('Delay canceled'));
+		}
+	};
 
 	return thunk;
 };
 
 module.exports = generate(true);
 module.exports.reject = generate(false);
+module.exports.CancelError = CancelError;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "promises",
     "bluebird"
   ],
+  "dependencies": {
+    "p-defer": "^1.0.0"
+  },
   "devDependencies": {
     "ava": "*",
     "bluebird": "^3.3.5",

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,19 @@ Promise.resolve('foo')
 		// executed 100 milliseconds later
 		// err === 'bar'
 	});
+
+// you can cancel the promise by calling .cancel()
+async () => {
+	const delaying = delay(1000);
+	setTimeout(() => {
+		delaying.cancel();
+	}, 500);
+	try {
+		await delaying;
+	} catch (err) {
+		// err is an instance of delay.CancelError
+	}
+}();
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import timeSpan from 'time-span';
 import inRange from 'in-range';
 // TODO: this is deprecated, switch it out with the `currently-unhandled` module
 import trackRejections from 'loud-rejection/api';
-import m from './';
+import m, {CancelError} from './';
 
 // install core-js promise globally, because Node 0.12 native promises don't generate unhandledRejection events
 global.Promise = Promise;
@@ -118,4 +118,15 @@ test.failing('rejected.then(rejectThunk).catch(handler) - should not create unha
 	t.deepEqual(tracker.currentlyUnhandled(), []);
 
 	tracker.currentlyUnhandled().forEach(({promise}) => promise.catch(() => {}));
+});
+
+test('can be canceled', async t => {
+	const delaying = m(1000);
+	delaying.cancel();
+	try {
+		await delaying;
+		t.fail();
+	} catch (err) {
+		t.true(err instanceof CancelError);
+	}
 });


### PR DESCRIPTION
As suggested in #15.

Notes:

1. This depends on #16.
2. Currently, `abort()` throws an `AbortError`. Perhaps that behavior should be optional? I usually find myself wanting to cancel everything that follows, and I'd rather not add a `catch` in those cases.
3. I'm introducing a dependency on `p-defer`, which is lightweight, but still relevant.
4. I'm not entirely sure which issue the [unhandled rejection handler](https://github.com/sindresorhus/delay/blob/cfb93d272ae916b01a78a5ae156553209de986f0/index.js#L19) originally solved, so the PR probably introduces an issue with that. I'm not getting any warnings from the tests though. Is it the known failure in the tests?