### PR TITLE
Remove `.cancel()` in favor of `.clear()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,22 @@
 'use strict';
 
-class CancelError extends Error {
-	constructor(message) {
-		super(message);
-		this.name = 'CancelError';
-	}
-}
-
 const createDelay = willResolve => (ms, value) => {
 	let timeoutId;
-	let internalReject;
+	let settle;
 
 	const delayPromise = new Promise((resolve, reject) => {
-		internalReject = reject;
+		settle = willResolve ? resolve : reject;
 
 		timeoutId = setTimeout(() => {
-			const settle = willResolve ? resolve : reject;
 			settle(value);
 		}, ms);
 	});
 
-	delayPromise.cancel = () => {
+	delayPromise.clear = () => {
 		if (timeoutId) {
 			clearTimeout(timeoutId);
 			timeoutId = null;
-			internalReject(new CancelError('Delay canceled'));
+			settle(value);
 		}
 	};
 
@@ -33,4 +25,3 @@ const createDelay = willResolve => (ms, value) => {
 
 module.exports = createDelay(true);
 module.exports.reject = createDelay(false);
-module.exports.CancelError = CancelError;

--- a/readme.md
+++ b/readme.md
@@ -51,17 +51,17 @@ delay.reject(100, 'foo'))
 		// err === 'foo'
 	});
 
-// You can cancel the promise by calling `.cancel()`
+// You can settle the delay by calling `.clear()`
 (async () => {
-	try {
-		const delayedPromise = delay(1000);
-		setTimeout(() => {
-			delayedPromise.cancel();
-		}, 500);
-		await delayedPromise;
-	} catch (err) {
-		// `err` is an instance of `delay.CancelError`
-	}
+	const delayedPromise = delay(1000, 'done!');
+
+	setTimeout(() => {
+		delayedPromise.clear();
+	}, 500);
+
+	const result = await delayedPromise;
+	// 500 milliseconds later
+	// result === 'done!'
 })();
 ```
 
@@ -90,17 +90,13 @@ Type: `any`
 
 Value to resolve or reject in the returned promise.
 
-### delay.CancelError
+### delay#clear()
 
-Exposed for instance checking.
-
-### delay#cancel()
-
-Cancel the delay. Results in the promise being rejected with a `delay.CancelError` error.
+Clears the delay and settles the promise.
 
 
 ## Related
-
+- [p-cancelable](https://github.com/sindresorhus/p-cancelable) - Create a promise that can be canceled
 - [p-min-delay](https://github.com/sindresorhus/p-min-delay) - Delay a promise a minimum amount of time
 - [p-immediate](https://github.com/sindresorhus/p-immediate) - Returns a promise resolved in the next event loop - think `setImmediate()`
 - [p-timeout](https://github.com/sindresorhus/p-timeout) - Timeout a promise after a specified amount of time

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ import {serial as test} from 'ava';
 import timeSpan from 'time-span';
 import inRange from 'in-range';
 import currentlyUnhandled from 'currently-unhandled';
-import m, {CancelError} from './';
+import m from './';
 
 const getCurrentlyUnhandled = currentlyUnhandled();
 
@@ -65,8 +65,27 @@ test('reject will cause an unhandledRejection if not caught', async t => {
 	t.deepEqual(getCurrentlyUnhandled(), [], 'no unhandled rejections now');
 });
 
-test('can be canceled', async t => {
-	const delayPromise = m(1000);
-	delayPromise.cancel();
-	await t.throws(delayPromise, CancelError);
+test('can clear a delayed resolution', async t => {
+	const end = timeSpan();
+	const delayPromise = m(1000, 'success!');
+
+	delayPromise.clear();
+	const success = await delayPromise;
+
+	t.true(end() < 30);
+	t.is(success, 'success!');
+});
+
+test('can clear a delayed rejection', async t => {
+	const end = timeSpan();
+	const delayPromise = m.reject(1000, 'error!');
+
+	delayPromise.clear();
+	try {
+		await delayPromise;
+	} catch (err) {
+		t.is(err, 'error!');
+	}
+
+	t.true(end() < 30);
 });


### PR DESCRIPTION
 - remove CancelError
 - settle upon clear instead of reject
 - document `.clear()`
 - add p-cancelable to 'Related' list
 - test both a cleared resolved and rejected promise