### PR TITLE
Add support for passing `AbortSignal` and move the `value` argument into options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,6 @@ declare const delay: {
 	 * Create a promise which rejects after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
-	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which rejects after the specified `milliseconds`.
 	 */
 	// TODO: Allow providing value type after https://github.com/Microsoft/TypeScript/issues/5413 will be resolved.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,36 +5,46 @@ interface ClearablePromise<T> extends Promise<T> {
 	clear(): void;
 }
 
+interface DelayOptions {
+	/**
+	 * An optional AbortSignal to abort the delay.
+	 * If aborted, the Promise will be rejected with an AbortError.
+	 */
+	signal?: AbortSignal
+}
+
 declare const delay: {
 	/**
 	 * Create a promise which resolves after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
-	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	(milliseconds: number, signal?: AbortSignal): ClearablePromise<void>;
+	(milliseconds: number, options?: DelayOptions): ClearablePromise<void>;
 
 	/**
 	 * Create a promise which resolves after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
-	 * @param value - Value to resolve in the returned promise.
-	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	<T>(milliseconds: number, value: T, signal?: AbortSignal): ClearablePromise<T>;
+	<T>(milliseconds: number, options?: DelayOptions & {
+		/** Value to resolve in the returned promise. */
+		value: T
+	}): ClearablePromise<T>;
 
 	/**
 	 * Create a promise which rejects after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
-	 * @param reason - Value to reject in the returned promise.
 	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which rejects after the specified `milliseconds`.
 	 */
-	// TODO: Allow providing reason type after https://github.com/Microsoft/TypeScript/issues/5413 will be resolved.
-	reject(milliseconds: number, reason?: any, signal?: AbortSignal): ClearablePromise<never>;
+	// TODO: Allow providing value type after https://github.com/Microsoft/TypeScript/issues/5413 will be resolved.
+	reject(milliseconds: number, options?: DelayOptions & {
+		/** Value to reject in the returned promise. */
+		value?: any
+	}): ClearablePromise<never>;
 };
 
 export default delay;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,28 +10,31 @@ declare const delay: {
 	 * Create a promise which resolves after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
+	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	(milliseconds: number): ClearablePromise<void>;
+	(milliseconds: number, signal?: AbortSignal): ClearablePromise<void>;
 
 	/**
 	 * Create a promise which resolves after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
 	 * @param value - Value to resolve in the returned promise.
+	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	<T>(milliseconds: number, value: T): ClearablePromise<T>;
+	<T>(milliseconds: number, value: T, signal?: AbortSignal): ClearablePromise<T>;
 
 	/**
 	 * Create a promise which rejects after the specified `milliseconds`.
 	 *
 	 * @param milliseconds - Milliseconds to delay the promise.
 	 * @param reason - Value to reject in the returned promise.
+	 * @param signal - An optional AbortSignal to abort the delay. If aborted, the Promise will be rejected with an AbortError.
 	 * @returns A promise which rejects after the specified `milliseconds`.
 	 */
 	// TODO: Allow providing reason type after https://github.com/Microsoft/TypeScript/issues/5413 will be resolved.
-	reject(milliseconds: number, reason?: any): ClearablePromise<never>;
+	reject(milliseconds: number, reason?: any, signal?: AbortSignal): ClearablePromise<never>;
 };
 
 export default delay;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,42 @@
 'use strict';
 
-const createDelay = willResolve => (ms, value) => {
+const createAbortError = () => {
+	const error = new Error('Delay aborted');
+	error.name = 'AbortError';
+	return error;
+};
+
+const isAbortSignal = value =>
+	typeof value === 'object' &&
+	value !== null &&
+	typeof value.aborted === 'boolean' &&
+	typeof value.addEventListener === 'function';
+
+const createDelay = willResolve => (ms, value, signal) => {
+	if (isAbortSignal(value)) {
+		signal = value;
+		value = undefined;
+	}
+	if (signal && signal.aborted) {
+		return Promise.reject(createAbortError());
+	}
+
 	let timeoutId;
 	let settle;
+	let rejectFn;
 
 	const delayPromise = new Promise((resolve, reject) => {
 		settle = willResolve ? resolve : reject;
+		rejectFn = reject;
 		timeoutId = setTimeout(settle, ms, value);
 	});
+
+	if (signal) {
+		signal.addEventListener('abort', () => {
+			clearTimeout(timeoutId);
+			rejectFn(createAbortError());
+		});
+	}
 
 	delayPromise.clear = () => {
 		if (timeoutId) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const createDelay = willResolve => (ms, {value, signal} = {}) => {
 		signal.addEventListener('abort', () => {
 			clearTimeout(timeoutId);
 			rejectFn(createAbortError());
-		});
+		}, {once: true});
 	}
 
 	delayPromise.clear = () => {

--- a/index.js
+++ b/index.js
@@ -6,17 +6,7 @@ const createAbortError = () => {
 	return error;
 };
 
-const isAbortSignal = value =>
-	typeof value === 'object' &&
-	value !== null &&
-	typeof value.aborted === 'boolean' &&
-	typeof value.addEventListener === 'function';
-
-const createDelay = willResolve => (ms, value, signal) => {
-	if (isAbortSignal(value)) {
-		signal = value;
-		value = undefined;
-	}
+const createDelay = willResolve => (ms, {value, signal} = {}) => {
 	if (signal && signal.aborted) {
 		return Promise.reject(createAbortError());
 	}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"bluebird"
 	],
 	"devDependencies": {
+		"abort-controller": "^1.0.2",
 		"ava": "*",
 		"currently-unhandled": "^0.4.1",
 		"in-range": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -31,14 +31,14 @@ const delay = require('delay');
 ```js
 const delay = require('delay');
 
-delay(100, 'a result')
+delay(100, { value: 'a result' })
 	.then(result => {
 		// Executed after 100 milliseconds
 		// result === 'a result';
 	});
 
 // There's also `delay.reject()` which optionally accepts a value and rejects it `ms` later
-delay.reject(100, 'foo'))
+delay.reject(100, { value: 'foo' }))
 	.then(x => blah()) // Never executed
 	.catch(err => {
 		// Executed 100 milliseconds later
@@ -47,7 +47,7 @@ delay.reject(100, 'foo'))
 
 // You can settle the delay by calling `.clear()`
 (async () => {
-	const delayedPromise = delay(1000, 'done!');
+	const delayedPromise = delay(1000, { value: 'done!' });
 
 	setTimeout(() => {
 		delayedPromise.clear();
@@ -68,7 +68,7 @@ delay.reject(100, 'foo'))
 	}, 500);
 
 	try {
-		await delay(1000, abortController.signal);
+		await delay(1000, { signal: abortController.signal });
 	} catch (err) {
 		// 500ms later:
 		// err.name === 'AbortError'

--- a/readme.md
+++ b/readme.md
@@ -57,20 +57,42 @@ delay.reject(100, 'foo'))
 	// 500 milliseconds later
 	// result === 'done!'
 })();
+
+// You can abort the delay with an AbortSignal as the last parameter
+(async () => {
+	const abortController = new AbortController();
+
+	const delayedPromise = delay(1000, abortController.signal);
+
+	setTimeout(() => {
+		abortController.abort();
+	}, 500);
+
+	try {
+		await delayedPromise;
+	} catch (err) {
+		// 500ms later:
+		// err.name === 'AbortError'
+	}
+})();
 ```
 
 
 ## API
 
-### delay(ms, [value])
+### delay(ms, [value], [signal])
 
 Create a promise which resolves after the specified `ms`. Optionally pass a
 `value` to resolve.
+If the last parameter is an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal),
+the returned Promise will be rejected with an AbortError when the signal is aborted.
 
-### delay.reject(ms, [value])
+### delay.reject(ms, [value], [signal])
 
 Create a promise which rejects after the specified `ms`. Optionally pass a
 `value` to reject.
+If the last parameter is an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal),
+the returned Promise will be rejected with an AbortError when the signal is aborted.
 
 #### ms
 
@@ -83,6 +105,12 @@ Milliseconds to delay the promise.
 Type: `any`
 
 Value to resolve or reject in the returned promise.
+
+#### signal
+
+Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+
+Signal to abort the delay.
 
 ### delay#clear()
 

--- a/readme.md
+++ b/readme.md
@@ -58,18 +58,17 @@ delay.reject(100, 'foo'))
 	// result === 'done!'
 })();
 
-// You can abort the delay with an AbortSignal as the last parameter
+// In the browser, you can abort the delay with an AbortSignal as the last parameter
+// There is a ponyfill for NodeJS: https://www.npmjs.com/package/abort-controller
 (async () => {
 	const abortController = new AbortController();
 
-	const delayedPromise = delay(1000, abortController.signal);
-
 	setTimeout(() => {
-		abortController.abort();
+		abortController.abort()
 	}, 500);
 
 	try {
-		await delayedPromise;
+		await delay(1000, abortController.signal);
 	} catch (err) {
 		// 500ms later:
 		// err.name === 'AbortError'
@@ -80,19 +79,13 @@ delay.reject(100, 'foo'))
 
 ## API
 
-### delay(ms, [value], [signal])
+### delay(ms, [options])
 
-Create a promise which resolves after the specified `ms`. Optionally pass a
-`value` to resolve.
-If the last parameter is an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal),
-the returned Promise will be rejected with an AbortError when the signal is aborted.
+Create a promise which resolves after the specified `ms`.
 
-### delay.reject(ms, [value], [signal])
+### delay.reject(ms, [options])
 
-Create a promise which rejects after the specified `ms`. Optionally pass a
-`value` to reject.
-If the last parameter is an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal),
-the returned Promise will be rejected with an AbortError when the signal is aborted.
+Create a promise which rejects after the specified `ms`.
 
 #### ms
 
@@ -100,19 +93,21 @@ Type: `number`
 
 Milliseconds to delay the promise.
 
-#### value
+#### options.value
 
 Type: `any`
 
-Value to resolve or reject in the returned promise.
+Optional value to resolve or reject in the returned promise.
 
-#### signal
+#### options.signal
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 
-Signal to abort the delay.
+Optional AbortSignal to abort the delay.
+The returned Promise will be rejected with an AbortError when the signal is aborted.
+AbortSignal is available in all modern browsers and there is a [ponyfill for NodeJS](https://www.npmjs.com/package/abort-controller).
 
-### delay#clear()
+### delayPromise.clear()
 
 Clears the delay and settles the promise.
 


### PR DESCRIPTION
This adds support for aborting a delay through the native [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).

This allows writing functions with async/await where the signal can just be passed down through functions without much boilerplate (in opposite to cancellable Promises). It is the cancellation mechanism used by modern APIs like fetch and WebAuthentication.

Example use:
```ts
async function pollStatus(signal) {
	while (true) {
		const status = await fetchStatus(signal)
		if (status === 'pending') {
			await delay(1000, signal)
 			continue
		}
		return status
	}
}
async function fetchStatus(signal) {
	const resp = await fetch('/api/status', { signal })
	checkStatus(resp)
	return await resp.json()
}
```

When the AbortSignal is aborted, it rejects with an AbortError like fetch does. This is so calling code does not continue execution and gets a chance to clean up resources in `finally` blocks. At the top level the error can be checked with `err.name === 'AbortError'`.

I chose to allow passing `AbortSignal` as a second parameter too, which technically prevents users from using an AbortSignal as a resolve value, but I think the chance that someone wants to do that intentionally is basically zero. It would be possible to require `delay(1000, null, signal)` instead, but that would probably more bugs than the alternative.