### PR TITLE
Include `dom` library in TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-/// <reference lib="dom" />
+/// <reference lib="dom"/>
 
 interface ClearablePromise<T> extends Promise<T> {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 interface ClearablePromise<T> extends Promise<T> {
 	/**
 	 * Clears the delay and settles the promise.


### PR DESCRIPTION
I'm getting 

```
node_modules/delay/index.d.ts:13:11 - error TS2304: Cannot find name 'AbortSignal'.

13  signal?: AbortSignal
             ~~~~~~~~~~~
```

then I try to use `delay` module.

It is because AbortSignal is in DOM library and then `/// <reference lib="dom" />` pragma should be used.
