### PR TITLE
[WIP] Refactor the options interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom"/>
 
+type Omit<Interface, Properties extends keyof Interface> = Pick<Interface, Exclude<keyof Interface, Properties>>;
+
 export interface ClearablePromise<T> extends Promise<T> {
 	/**
 	 * Clears the delay and settles the promise.
@@ -7,12 +9,16 @@ export interface ClearablePromise<T> extends Promise<T> {
 	clear(): void;
 }
 
-export interface Options {
+export interface Options<Value = any> {
 	/**
 	 * An optional AbortSignal to abort the delay.
 	 * If aborted, the Promise will be rejected with an AbortError.
 	 */
-	signal?: AbortSignal
+	signal?: AbortSignal,
+	/**
+	 * Value to resolve in the returned promise.
+	 */
+	value: Value
 }
 
 declare const delay: {
@@ -22,7 +28,7 @@ declare const delay: {
 	 * @param milliseconds - Milliseconds to delay the promise.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	(milliseconds: number, options?: Options): ClearablePromise<void>;
+	(milliseconds: number, options?: Omit<Options, 'value'>): ClearablePromise<void>;
 
 	/**
 	 * Create a promise which resolves after the specified `milliseconds`.
@@ -30,10 +36,7 @@ declare const delay: {
 	 * @param milliseconds - Milliseconds to delay the promise.
 	 * @returns A promise which resolves after the specified `milliseconds`.
 	 */
-	<T>(milliseconds: number, options?: Options & {
-		/** Value to resolve in the returned promise. */
-		value: T
-	}): ClearablePromise<T>;
+	<Value>(milliseconds: number, options?: Options<Value>): ClearablePromise<Value>;
 
 	/**
 	 * Create a promise which rejects after the specified `milliseconds`.
@@ -42,10 +45,7 @@ declare const delay: {
 	 * @returns A promise which rejects after the specified `milliseconds`.
 	 */
 	// TODO: Allow providing value type after https://github.com/Microsoft/TypeScript/issues/5413 will be resolved.
-	reject(milliseconds: number, options?: Options & {
-		/** Value to reject in the returned promise. */
-		value?: any
-	}): ClearablePromise<never>;
+	reject(milliseconds: number, options?: Options): ClearablePromise<never>;
 };
 
 export default delay;


### PR DESCRIPTION
I came across this solution in this [thread](https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-409165610). It's more experimental and maybe we can take some ideas from it.

However, it's not 100% identical to what we had. Because when using `.reject()`, the `value` is optional, which doesn't look like I can do easily with this approach.

A second approach could be to just do this

```ts
export interface Options {
	signal?: AbortSignal,
}

export interface ValueOptions<Value> {
	value: Value
}

declare const delay: {
	(milliseconds: number, options?: Options): ClearablePromise<void>;

	<Value>(milliseconds: number, options?: Options & ValueOptions<Value>): ClearablePromise<Value>;

	reject(milliseconds: number, options?: Options & Partial<ValueOptions<Value>>): ClearablePromise<never>;
};
```

Wrapping it in `Partial` makes all the properties of that interface optional.

I would be fine with keeping it as is though. Just wanted to share my ideas.