### PR TITLE
Remove dependency on `dom.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,17 @@ export interface ClearablePromise<T> extends Promise<T> {
 	clear(): void;
 }
 
+/**
+ * Minimal subset of `AbortSignal` that delay will use if passed.
+ * This avoids a dependency on dom.d.ts.
+ * The dom.d.ts `AbortSignal` is compatible with this one.
+ */
+interface AbortSignal {
+	readonly aborted: boolean;
+	addEventListener(type: 'abort', listener: () => void, options?: { once?: boolean }): void;
+	removeEventListener(type: 'abort', listener: () => void): void;
+}
+
 export interface Options {
 	/**
 	 * An optional AbortSignal to abort the delay.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom"/>
-
 export interface ClearablePromise<T> extends Promise<T> {
 	/**
 	 * Clears the delay and settles the promise.


### PR DESCRIPTION
Closes https://github.com/sindresorhus/delay/issues/40

Adds a subset of the AbortSignal interface that delay uses.

Since the interfaces are compatible you can still do this:

```ts
import delay from 'delay'

delay(100, { signal: new AbortController().signal })
```
(I verified this still works)

But there will be no errors if you don't use dom.d.ts, and you could even provide an object that conforms to this interface in a non-DOM environment and it will work fine.
This includes all parts of the AbortSignal interface that we use and excludes all the stuff that we don't (and will never), like `passive`/`capture` EventListener options, or the legacy `onabort` setter.