### PR TITLE
Adds string support for ms definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const dt = require('delta-time');
+
 const createAbortError = () => {
 	const error = new Error('Delay aborted');
 	error.name = 'AbortError';
@@ -38,7 +40,7 @@ const createDelay = ({clearTimeout: defaultClear, setTimeout: set, willResolve})
 		};
 
 		rejectFn = reject;
-		timeoutId = (set || setTimeout)(settle, ms);
+		timeoutId = (set || setTimeout)(settle, dt(ms));
 	});
 
 	if (signal) {

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
 		"time-span": "^3.0.0",
 		"tsd": "^0.7.1",
 		"xo": "^0.24.0"
+	},
+	"dependencies": {
+		"delta-time": "^2.0.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,9 @@ Create a promise which rejects after the specified `milliseconds`.
 
 #### milliseconds
 
-Type: `number`
+Type: `number` or `string`
 
-Milliseconds to delay the promise.
+Milliseconds to delay the promise either as a number or a [time string](https://github.com/repraze-org/delta-time).
 
 #### options
 
@@ -67,6 +67,21 @@ Clears the delay and settles the promise.
 Creates a new `delay` instance using the provided functions for clearing and setting timeouts. Useful if you're about to stub timers globally, but you still want to use `delay` to manage your tests.
 
 ## Advanced usage
+
+Using `string` for `milliseconds`:
+
+```js
+const delay = require('delay');
+
+(async () => {
+	bar();
+
+	await delay('2s');
+
+	// Executed 2000 milliseconds later
+	baz();
+})();
+```
 
 Passing a value:
 

--- a/test.js
+++ b/test.js
@@ -44,6 +44,12 @@ test('delay defaults to 0 ms', async t => {
 	t.true(end() < 30);
 });
 
+test('delay with string', async t => {
+	const end = timeSpan();
+	await m('100 millis 0.1 second');
+	t.true(inRange(end(), 190, 300), 'is delayed');
+});
+
 test('reject will cause an unhandledRejection if not caught', async t => {
 	const reason = new Error('foo');
 	const promise = m.reject(0, {value: reason});


### PR DESCRIPTION
Adds support for advanced milliseconds definition from string using delta-time package. After this, milliseconds can be passed as '10 secs' ans so on. The `delta-time` milliseconds computation is similar to `ms`, although it allows more granularity of definition:

``` js
await delay('1s 500ms');
```

This is a proposal, as I understand the current implementation of delay holds no dependencies and you can achieve the same behavior by parsing string before using delay.

I was looking around to see other promised based timeout system to contribute to before publishing my own. I believe it is a common use case and makes our source code more readable. :watch: