### PR TITLE
add millisecond range

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,14 @@ type Delay = {
 	@returns A promise which resolves after the specified `milliseconds`.
 	*/
 	(milliseconds: number, options?: delay.Options): delay.ClearablePromise<void>;
+	/**
+	 Create a promise which resolves after a random time in the range [`milliseconds`, `millisecondsTo`).
+
+	 @param millisecondsFrom - Lower bound of random number of milliseconds to delay the promise.
+	 @param millisecondsTo - Upper bound of random number of milliseconds to delay the promise.
+	 @returns A promise that resolves thereafter.
+	 */
+	(millisecondsFrom: number, millisecondsTo: number, options?: delay.Options): delay.ClearablePromise<void>;
 
 	/**
 	Create a promise which resolves after the specified `milliseconds`.
@@ -51,6 +59,23 @@ type Delay = {
 			/**
 			Value to resolve in the returned promise.
 			*/
+			value: T;
+		}
+	): delay.ClearablePromise<T>;
+	/**
+	 Create a promise which resolves after a random time in the range [`milliseconds`, `millisecondsTo`).
+
+	 @param millisecondsFrom - Lower bound of random number of milliseconds to delay the promise.
+	 @param millisecondsTo - Upper bound of random number of milliseconds to delay the promise.
+	 @returns A promise that resolves thereafter.
+	 */
+	<T>(
+		millisecondsFrom: number,
+		millisecondsTo: number,
+		options?: delay.Options & {
+			/**
+			 Value to resolve in the returned promise.
+			 */
 			value: T;
 		}
 	): delay.ClearablePromise<T>;
@@ -68,6 +93,23 @@ type Delay = {
 			/**
 			Value to reject in the returned promise.
 			*/
+			value?: unknown;
+		}
+	): delay.ClearablePromise<never>;
+	/**
+	 Create a promise which rejects after a random time in the range `millisecondsFrom` and `millisecondsTo`.
+
+	 @param millisecondsFrom - Lower bound of random number of milliseconds to delay the promise.
+	 @param millisecondsTo - Upper bound of random number of milliseconds to delay the promise.
+	 @returns A promise that resolves thereafter.
+	 */
+	reject(
+		millisecondsFrom: number,
+		millisecondsTo: number,
+		options?: delay.Options & {
+			/**
+			 Value to reject in the returned promise.
+			 */
 			value?: unknown;
 		}
 	): delay.ClearablePromise<never>;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const createDelay = ({clearTimeout: defaultClear, setTimeout: set, willResolve})
 		value = msRangeTo.value;
 		signal = msRangeTo.signal;
 	} else if (typeof msRangeTo === 'number') {
-		ms = Math.floor(Math.random() * (msRangeTo - ms + 1) + ms);
+		ms = Math.floor((Math.random() * (msRangeTo - ms + 1)) + ms);
 	}
 
 	if (signal && signal.aborted) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,14 @@ const createAbortError = () => {
 	return error;
 };
 
-const createDelay = ({clearTimeout: defaultClear, setTimeout: set, willResolve}) => (ms, {value, signal} = {}) => {
+const createDelay = ({clearTimeout: defaultClear, setTimeout: set, willResolve}) => (ms, msRangeTo, {value, signal} = {}) => {
+	if (typeof msRangeTo === 'object') {
+		value = msRangeTo.value;
+		signal = msRangeTo.signal;
+	} else if (typeof msRangeTo === 'number') {
+		ms = Math.floor(Math.random() * (msRangeTo - ms + 1) + ms);
+	}
+
 	if (signal && signal.aborted) {
 		return Promise.reject(createAbortError());
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,9 +16,12 @@ expectType<ClearablePromise<never>>(delay.reject(200, {value: 0}));
 
 const customDelay = delay.createWithTimers({clearTimeout, setTimeout});
 expectType<ClearablePromise<void>>(customDelay(200));
+expectType<ClearablePromise<void>>(customDelay(200, 400));
 
 expectType<ClearablePromise<string>>(customDelay(200, {value: '🦄'}));
 expectType<ClearablePromise<number>>(customDelay(200, {value: 0}));
+expectType<ClearablePromise<number>>(customDelay(200, 400, {value: 0}));
 
 expectType<ClearablePromise<never>>(customDelay.reject(200, {value: '🦄'}));
 expectType<ClearablePromise<never>>(customDelay.reject(200, {value: 0}));
+expectType<ClearablePromise<never>>(customDelay.reject(200, 400, {value: 0}));

--- a/readme.md
+++ b/readme.md
@@ -32,15 +32,29 @@ const delay = require('delay');
 
 Create a promise which resolves after the specified `milliseconds`.
 
+### delay(millisecondsFrom, millisecondsTo, [options])
+
+Create a promise which resolves after a random time in the range [`milliseconds`, `millisecondsTo`).
+
 ### delay.reject(milliseconds, [options])
 
 Create a promise which rejects after the specified `milliseconds`.
+
+### delay.reject(millisecondsFrom, millisecondsTo, [options])
+
+Create a promise which rejects after a random time in the range [`milliseconds`, `millisecondsTo`).
 
 #### milliseconds
 
 Type: `number`
 
 Milliseconds to delay the promise.
+
+#### millisecondsFrom, millisecondsTo
+
+Type: `number`
+
+If provided, the promise will be delayed by a random number of milliseconds in the range [milliseconds, millisecondsTo).
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -13,6 +13,12 @@ test('returns a resolved promise', async t => {
 	t.true(inRange(end(), 30, 70), 'is delayed');
 });
 
+test('returns a resolved promise for delay range', async t => {
+	const end = timeSpan();
+	await m(30, 70);
+	t.true(inRange(end(), 10, 90), 'is delayed');
+});
+
 test('returns a rejected promise', async t => {
 	const end = timeSpan();
 	await t.throwsAsync(
@@ -20,6 +26,22 @@ test('returns a rejected promise', async t => {
 		'foo'
 	);
 	t.true(inRange(end(), 30, 70), 'is delayed');
+});
+
+test('returns a rejected promise for delay range', async t => {
+	const end = timeSpan();
+	await t.throwsAsync(
+		m.reject(50, {value: new Error('foo')}),
+		'foo'
+	);
+	t.true(inRange(end(), 10, 90), 'is delayed');
+});
+
+test('resolves with value and delay range', async t => {
+	t.is(
+		await m(50, 70, {value: 0}),
+		0
+	);
 });
 
 test('able to resolve a falsy value', async t => {
@@ -87,6 +109,17 @@ test('resolution can be aborted with an AbortSignal', async t => {
 	setTimeout(() => abortController.abort(), 1);
 	await t.throwsAsync(
 		m(1000, {signal: abortController.signal}),
+		{name: 'AbortError'}
+	);
+	t.true(end() < 30);
+});
+
+test('resolution can be aborted with an AbortSignal and delay range', async t => {
+	const end = timeSpan();
+	const abortController = new AbortController();
+	setTimeout(() => abortController.abort(), 1);
+	await t.throwsAsync(
+		m(5000, 1000, {signal: abortController.signal}),
 		{name: 'AbortError'}
 	);
 	t.true(end() < 30);

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test('resolution can be aborted with an AbortSignal and delay range', async t =>
 	const abortController = new AbortController();
 	setTimeout(() => abortController.abort(), 1);
 	await t.throwsAsync(
-		m(5000, 1000, {signal: abortController.signal}),
+		m(1000, 5000, {signal: abortController.signal}),
 		{name: 'AbortError'}
 	);
 	t.true(end() < 30);


### PR DESCRIPTION
In many applications it's useful to delay promises by different amounts of time within a defined range (one example is web scrapers). This PR makes a suggestion to include this capability in the module by having `delay` take in a second optional milliseconds parameter, which together with the required first value formulate the range from which a random number will be used to delay the promise.