### PR TITLE
Fix missing `range()` in `createWithTimers()` return value & require Node.js 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
-          - 6
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/index.js
+++ b/index.js
@@ -57,14 +57,15 @@ const createDelay = ({clearTimeout: defaultClear, setTimeout: set, willResolve})
 	return delayPromise;
 };
 
-const delay = createDelay({willResolve: true});
-delay.reject = createDelay({willResolve: false});
-delay.range = (minimum, maximum, options) => delay(randomInteger(minimum, maximum), options);
-delay.createWithTimers = ({clearTimeout, setTimeout}) => {
-	const delay = createDelay({clearTimeout, setTimeout, willResolve: true});
-	delay.reject = createDelay({clearTimeout, setTimeout, willResolve: false});
+const createWithTimers = clearAndSet => {
+	const delay = createDelay({...clearAndSet, willResolve: true});
+	delay.reject = createDelay({...clearAndSet, willResolve: false});
+	delay.range = (minimum, maximum, options) => delay(randomInteger(minimum, maximum), options);
 	return delay;
 };
+
+const delay = createWithTimers();
+delay.createWithTimers = createWithTimers;
 
 module.exports = delay;
 // TODO: Remove this for the next major release

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"

--- a/test.js
+++ b/test.js
@@ -125,6 +125,12 @@ test('rejects with AbortError if AbortSignal is already aborted', async t => {
 	t.true(end() < 30);
 });
 
+test('returns a promise that is resolved in a random range of time', async t => {
+	const end = timeSpan();
+	await delay.range(50, 150);
+	t.true(inRange(end(), 30, 170), 'is delayed');
+});
+
 test('can create a new instance with fixed timeout methods', async t => {
 	const cleared = [];
 	const callbacks = [];
@@ -162,10 +168,10 @@ test('can create a new instance with fixed timeout methods', async t => {
 	third.clear();
 	t.is(cleared.length, 1);
 	t.is(cleared[0], callbacks[2].handle);
-});
 
-test('returns a promise that is resolved in a random range of time', async t => {
-	const end = timeSpan();
-	await delay.range(50, 150);
-	t.true(inRange(end(), 30, 170), 'is delayed');
+	const fourth = custom.range(50, 150, {value: 'fourth'});
+	t.is(callbacks.length, 4);
+	t.true(inRange(callbacks[2].ms, 50, 150));
+	callbacks[3].callback();
+	t.is(await fourth, 'fourth');
 });


### PR DESCRIPTION
This started with a simple bugfix:

* DRY `delay` creation
* Add test for range() and createWithTimers()

Except that Node.js 6 doesn't do object spread. So I've changed this to require Node.js 10.

Which requires a breaking change, so I've removed the default export.

---

I'd appreciate this if this can ship without also upgrading to use ESM.